### PR TITLE
Add Footer to Editor Page w/ unit tests

### DIFF
--- a/src/react/components/pages/editorPage/editorFooter.test.tsx
+++ b/src/react/components/pages/editorPage/editorFooter.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Footer from "./footer";
+import EditorFooter from "./editorFooter";
 import {mount} from "enzyme";
 import TagColors from "../../common/tagsInput/tagColors.json";
 
@@ -21,19 +21,25 @@ describe("Footer Component", () => {
     beforeEach(() => {
         onChangeHandler = jest.fn();
         wrapper = mount(
-            <Footer
+            <EditorFooter
                 tags={originalTags}
-                onChange={onChangeHandler}/>,
+                onTagsChanged={onChangeHandler}/>,
         );
     });
 
     it("tags are initialized correctly", () => {
         const stateTags = wrapper.state().tags;
-        expect(stateTags).toHaveLength(originalTags.length);
-        for (let i = 0; i < stateTags.length; i++) {
-            expect(stateTags[i].name).toEqual(originalTags[i].name);
-            expect(stateTags[i].color).toEqual(originalTags[i].color);
-        }
+        expect(stateTags).toEqual(originalTags);
+    });
+
+    it("tags are empty", () => {
+        const emptyWrapper = mount(
+            <EditorFooter
+                tags={[]}
+                onTagsChanged={onChangeHandler}/>,
+        );
+        const stateTags = emptyWrapper.state().tags;
+        expect(stateTags).toEqual([]);
     });
 
     it("create a new tag from text box", () => {

--- a/src/react/components/pages/editorPage/editorFooter.tsx
+++ b/src/react/components/pages/editorPage/editorFooter.tsx
@@ -2,22 +2,22 @@ import React from "react";
 import TagsInput from "../../common/tagsInput/tagsInput";
 import { ITag } from "../../../../models/applicationState";
 
-interface IFooterProps {
+export interface IEditorFooterProps {
     tags: ITag[];
-    onChange: (value) => void;
+    onTagsChanged: (value) => void;
 }
 
-interface IFooterState {
+export interface IEditorFooterState {
     tags: ITag[];
 }
 
-export default class Footer extends React.Component<IFooterProps, IFooterState> {
+export default class EditorFooter extends React.Component<IEditorFooterProps, IEditorFooterState> {
     constructor(props) {
         super(props);
         this.state = {
             tags: props.tags,
         };
-        this.onTagsChange = this.onTagsChange.bind(this);
+        this.onTagsChanged = this.onTagsChanged.bind(this);
     }
 
     public render() {
@@ -25,15 +25,15 @@ export default class Footer extends React.Component<IFooterProps, IFooterState> 
             <div>
                 <TagsInput
                     tags={this.state.tags}
-                    onChange={this.onTagsChange}
+                    onChange={this.onTagsChanged}
                 />
             </div>
         );
     }
 
-    private onTagsChange(tags) {
+    private onTagsChanged(tags) {
         this.setState({
             tags: JSON.parse(tags),
-        }, () => this.props.onChange(this.state));
+        }, () => this.props.onTagsChanged(this.state));
     }
 }

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps } from "react-router-dom";
 import HtmlFileReader from "../../../../common/htmlFileReader";
 import "./editorPage.scss";
 import AssetPreview from "./assetPreview";
+import Footer from "./footer";
 
 interface IEditorPageProps extends RouteComponentProps, React.Props<IEditorPageProps> {
     project: IProject;
@@ -48,6 +49,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         }
 
         this.selectAsset = this.selectAsset.bind(this);
+        this.onFooterChange = this.onFooterChange.bind(this);
     }
 
     public async componentDidMount() {
@@ -112,12 +114,23 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                             </div>
                         }
                     </div>
-                    <div className="editor-page-content-footer">
-                        Footer
+                    <div>
+                        <Footer
+                            tags={this.props.project.tags}
+                            onChange={this.onFooterChange} />
                     </div>
                 </div>
             </div>
         );
+    }
+
+    private onFooterChange(footerState) {
+        this.setState({
+            project: {
+                ...this.state.project,
+                tags: footerState.tags,
+            },
+        });
     }
 
     private async selectAsset(asset: IAsset) {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps } from "react-router-dom";
 import HtmlFileReader from "../../../../common/htmlFileReader";
 import "./editorPage.scss";
 import AssetPreview from "./assetPreview";
-import Footer from "./footer";
+import EditorFooter from "./editorFooter";
 
 interface IEditorPageProps extends RouteComponentProps, React.Props<IEditorPageProps> {
     project: IProject;
@@ -115,9 +115,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         }
                     </div>
                     <div>
-                        <Footer
+                        <EditorFooter
                             tags={this.props.project.tags}
-                            onChange={this.onFooterChange} />
+                            onTagsChanged={this.onFooterChange} />
                     </div>
                 </div>
             </div>

--- a/src/react/components/pages/editorPage/footer.test.tsx
+++ b/src/react/components/pages/editorPage/footer.test.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import TagsInput from "./tagsInput";
-import { mount } from "enzyme";
-import TagColors from "./tagColors.json";
-import { ITag } from "../../../../models/applicationState";
+import Footer from "./footer";
+import {mount} from "enzyme";
+import TagColors from "../../common/tagsInput/tagColors.json";
 
-describe("Tags Input Component", () => {
+describe("Footer Component", () => {
     let wrapper: any = null;
     let onChangeHandler: (value: any) => void;
 
@@ -22,7 +21,7 @@ describe("Tags Input Component", () => {
     beforeEach(() => {
         onChangeHandler = jest.fn();
         wrapper = mount(
-            <TagsInput
+            <Footer
                 tags={originalTags}
                 onChange={onChangeHandler}/>,
         );
@@ -32,18 +31,9 @@ describe("Tags Input Component", () => {
         const stateTags = wrapper.state().tags;
         expect(stateTags).toHaveLength(originalTags.length);
         for (let i = 0; i < stateTags.length; i++) {
-            expect(stateTags[i].id).toEqual(originalTags[i].name);
+            expect(stateTags[i].name).toEqual(originalTags[i].name);
             expect(stateTags[i].color).toEqual(originalTags[i].color);
-            expect(stateTags[i].text).not.toBeNull();
         }
-    });
-
-    it("renders appropriate number of color boxes", () => {
-        expect(wrapper.find("div.inline-block.tag_color_box")).toHaveLength(2);
-    });
-
-    it("one text input field is available", () => {
-        expect(wrapper.find("input")).toHaveLength(1);
     });
 
     it("create a new tag from text box", () => {
@@ -52,7 +42,7 @@ describe("Tags Input Component", () => {
         wrapper.find("input").simulate("keyDown", {keyCode: 13});
         expect(onChangeHandler).toBeCalled();
         expect(wrapper.state().tags).toHaveLength(3);
-        expect(wrapper.state().tags[2].id).toEqual(newTagName);
+        expect(wrapper.state().tags[2].name).toEqual(newTagName);
         expect(TagColors).toContain(wrapper.state().tags[2].color);
     });
 
@@ -62,24 +52,8 @@ describe("Tags Input Component", () => {
             .last().simulate("click");
         expect(onChangeHandler).toBeCalled();
         expect(wrapper.state().tags).toHaveLength(1);
-        expect(wrapper.state().tags[0].id).toEqual(originalTags[0].name);
+        expect(wrapper.state().tags[0].name).toEqual(originalTags[0].name);
         expect(wrapper.state().tags[0].color).toEqual(originalTags[0].color);
-    });
-
-    it("double click tag opens modal", () => {
-        expect(wrapper.state().showModal).toBeFalsy();
-        wrapper.find("div.inline-block.tagtext")
-            .first()
-            .simulate("dblclick", { target: { innerText: originalTags[0].name}});
-        expect(wrapper.state().showModal).toBeTruthy();
-    });
-
-    it("double click tag sets selected tag", () => {
-        wrapper.find("div.inline-block.tagtext")
-            .first()
-            .simulate("dblclick", { target: { innerText: originalTags[0].name}});
-        expect(wrapper.state().selectedTag.id).toEqual(originalTags[0].name);
-        expect(wrapper.state().selectedTag.color).toEqual(originalTags[0].color);
     });
 
     it("clicking 'ok' in modal closes and calls onChangeHandler", () => {
@@ -89,7 +63,6 @@ describe("Tags Input Component", () => {
         wrapper.find("button")
             .last()
             .simulate("click");
-        expect(wrapper.state().showModal).toBeFalsy();
         expect(onChangeHandler).toBeCalled();
     });
 
@@ -100,7 +73,7 @@ describe("Tags Input Component", () => {
         wrapper.find("button")
             .first()
             .simulate("click");
-        expect(wrapper.state().showModal).toBeFalsy();
         expect(onChangeHandler).not.toBeCalled();
     });
+
 });

--- a/src/react/components/pages/editorPage/footer.tsx
+++ b/src/react/components/pages/editorPage/footer.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import TagsInput from "../../common/tagsInput/tagsInput";
+import { ITag } from "../../../../models/applicationState";
+
+interface IFooterProps {
+    tags: ITag[];
+    onChange: (value) => void;
+}
+
+interface IFooterState {
+    tags: ITag[];
+}
+
+export default class Footer extends React.Component<IFooterProps, IFooterState> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            tags: props.tags,
+        };
+        this.onTagsChange = this.onTagsChange.bind(this);
+    }
+
+    public render() {
+        return (
+            <div>
+                <TagsInput
+                    tags={this.state.tags}
+                    onChange={this.onTagsChange}
+                />
+            </div>
+        );
+    }
+
+    private onTagsChange(tags) {
+        this.setState({
+            tags: JSON.parse(tags),
+        }, () => this.props.onChange(this.state));
+    }
+}

--- a/src/react/components/pages/projectSettings/projectSettingsPage.tsx
+++ b/src/react/components/pages/projectSettings/projectSettingsPage.tsx
@@ -68,6 +68,7 @@ export default class ProjectSettingsPage extends React.Component<IProjectSetting
     }
 
     private onFormSubmit = (form) => {
+        form.formData.tags = JSON.parse(form.formData.tags);
         this.setState({
             project: {
                 ...form.formData,


### PR DESCRIPTION
Unit tests are duplicated from tags input tests themselves. Just verifying the ability of the tags input within the footer to load correctly and actually change state